### PR TITLE
Add proto dependency to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,10 @@ endif
 
 PROTO_C_FILE = src/proto/protocol.pb.c
 
-
 ################
 # Default rule #
 ################
-all: $(PROTO_C_FILE) default 
+all: $(PROTO_C_FILE) default
 
 ############
 # Platform #


### PR DESCRIPTION
Running `make` will now watch for any changes to the `src/proto/protocol.proto` file and compile accordingly :)